### PR TITLE
Add ‘shipping_method’ and ‘shippng_note’ to whitelist

### DIFF
--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -97,7 +97,7 @@ return [
             'shipping_name', 'shipping_address_line1', 'shipping_address_line2', 'shipping_city', 'shipping_region',
             'shipping_postal_code', 'shipping_country', 'use_shipping_address_for_billing', 'billing_name', 'billing_address_line1',
             'billing_address_line2', 'billing_city', 'billing_region', 'billing_postal_code', 'billing_country',
-            'shipping_method', 'shipping_note'
+            'shipping_method', 'shipping_note',
         ],
 
         'line_items' => [],

--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -97,6 +97,7 @@ return [
             'shipping_name', 'shipping_address_line1', 'shipping_address_line2', 'shipping_city', 'shipping_region',
             'shipping_postal_code', 'shipping_country', 'use_shipping_address_for_billing', 'billing_name', 'billing_address_line1',
             'billing_address_line2', 'billing_city', 'billing_region', 'billing_postal_code', 'billing_country',
+            'shipping_method', 'shipping_note'
         ],
 
         'line_items' => [],


### PR DESCRIPTION
This pull requests updates the config's whitelist to include the `shipping_method` and `shipping_note` fields (otherwise they don't get saved to the Order).
