### PR TITLE
Update to latest version of simple-commerce

### DIFF
--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -23,4 +23,4 @@ export_paths:
   - tailwind.config.js
   - webpack.mix.js
 dependencies:
-  doublethreedigital/simple-commerce: "4.0.*"
+  doublethreedigital/simple-commerce: "4.2.*"


### PR DESCRIPTION
When installing on a blank project I had to update immediately, and thought the dependency could be bumped for a better starting experience.