### PR TITLE
fix checkout fields to align with order blueprints

### DIFF
--- a/resources/views/checkout/information.antlers.html
+++ b/resources/views/checkout/information.antlers.html
@@ -32,10 +32,10 @@
 
                         <div class="grid md:grid-cols-12 gap-6 mb-12">
                             {{ partial:components/forms/input_field width="50" handle="shipping_name" display="Shipping Name" required="true" }}
-                            {{ partial:components/forms/input_field width="50" handle="shipping_address_line1" display="Address Line 1" required="true" }}
+                            {{ partial:components/forms/input_field width="50" handle="shipping_address" display="Address Line 1" required="true" }}
                             {{ partial:components/forms/input_field width="50" handle="shipping_address_line2" display="Address Line 2" required="true" }}
                             {{ partial:components/forms/input_field width="50" handle="shipping_city" display="Town/City" required="true" }}
-                            {{ partial:components/forms/input_field width="50" handle="shipping_zip_code" display="Postal/Zip Code" required="true" }}
+                            {{ partial:components/forms/input_field width="50" handle="shipping_postal_code" display="Postal/Zip Code" required="true" }}
 
                             {{ partial:components/forms/select_field width="50" handle="shipping_country" display="Country" x-model="shippingCountry" required="true" }}
                                 {{ sc:countries common="GB|US|CA|DE" }}


### PR DESCRIPTION
The Shipping Address and Zip Code fields had different handles than what is in the Order blueprint. This was causing the Address and Zip to not show up in the Control Panel. 